### PR TITLE
Feature: Enable multi-arch Docker images

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
                 uses: docker/metadata-action@v4
                 with:
                     images: |
-                        aldissaramatheus/tasks.md
+                        baldissaramatheus/tasks.md
                     tags: |
                         # Process semver like tags
                         # For a tag x.y.z or vX.Y.Z, output an x.y.z,  x.y and x image tag

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,67 +9,46 @@ jobs:
     build:
         name: Build
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
 
-            -   uses: FranzDiebold/github-env-vars-action@v2
-
-            -   name: Set major tag name
-                run: echo "TAG_MAJOR=$(echo $CI_REF_NAME | cut -d. -f1)" >> $GITHUB_ENV
-
-            -   name: Set major tag name
-                run: echo "TAG_MINOR=${{ env.TAG_MAJOR }}.$(echo $CI_REF_NAME | cut -d. -f2)" >> $GITHUB_ENV
-
-            -   name: Build image
-                run: |
-                    docker build --no-cache \
-                        -t baldissaramatheus/tasks.md:latest \
-                        -t baldissaramatheus/tasks.md:$CI_REF_NAME \
-                        -t baldissaramatheus/tasks.md:${{ env.TAG_MAJOR }} \
-                        -t baldissaramatheus/tasks.md:${{ env.TAG_MINOR }} \
-                        .
-            -   name: Save Docker image as artifact
-                run: |
-                    docker save -o /tmp/image.tar \
-                        baldissaramatheus/tasks.md:latest \
-                        baldissaramatheus/tasks.md:$CI_REF_NAME \
-                        baldissaramatheus/tasks.md:${{ env.TAG_MAJOR }} \
-                        baldissaramatheus/tasks.md:${{ env.TAG_MINOR }}
-            -   name: Upload artifact
-                uses: actions/upload-artifact@v2
+            -   name: Gather Docker metadata
+                id: docker-meta
+                uses: docker/metadata-action@v4
                 with:
-                    name: image
-                    path: /tmp/image.tar
+                    images: |
+                        aldissaramatheus/tasks.md
+                    tags: |
+                        # Process semver like tags
+                        # For a tag x.y.z or vX.Y.Z, output an x.y.z,  x.y and x image tag
+                        type=semver,pattern={{version}}
+                        type=semver,pattern={{major}}.{{minor}}
+                        type=semver,pattern={{major}}
 
-    deploy:
-        name: Deploy
-
-        needs: [build]
-
-        runs-on: ubuntu-20.04
-
-        steps:
-            -   uses: FranzDiebold/github-env-vars-action@v2
-
-            -   name: Set major tag name
-                run: echo "TAG_MAJOR=$(echo $CI_REF_NAME | cut -d. -f1)" >> $GITHUB_ENV
-
-            -   name: Set major tag name
-                run: echo "TAG_MINOR=${{ env.TAG_MAJOR }}.$(echo $CI_REF_NAME | cut -d. -f2)" >> $GITHUB_ENV
-
-            -   name: Download artifact
-                uses: actions/download-artifact@v2
+            -   name: Login to Docker Hub
+                uses: docker/login-action@v2
+                # Don't attempt to login is not pushing to Docker Hub
+                if: github.event_name != 'pull_request'
                 with:
-                    name: image
-                    path: /tmp
+                    username: "${{ secrets.DOCKER_USERNAME }}"
+                    password: ${{ secrets.DOCKER_PASSWORD }}
 
-            -   name: Load Docker image
-                run: |
-                    docker load --input /tmp/image.tar
-                    docker image ls -a
-            -   name: Push Docker image
-                run: |
-                    echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-                    docker push --all-tags baldissaramatheus/tasks.md
+            # Login to GitHub container registry could happen here
+
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v2
+
+            -   name: Set up QEMU
+                uses: docker/setup-qemu-action@v2
+
+            -   name: Build and push
+                uses: docker/build-push-action@v4
+                with:
+                    context: .
+                    file: ./Dockerfile
+                    platforms: linux/amd64,linux/arm/v7,linux/arm64
+                    push: ${{ github.event_name != 'pull_request' }}
+                    tags: ${{ steps.docker-meta.outputs.tags }}
+                    labels: ${{ steps.docker-meta.outputs.labels }}


### PR DESCRIPTION
Draft until #6 is decided and I can rebase or drop the extra commit.

- Use `docker/metadata-action` to handle getting image tags and manage `:latest`.  For a tag `x.y.z`, this will produce the image tags `:x.y.z`, `:x.y` and `:x`, as well as updating `:latest` as necessary
  - Also provides standard image labels for free
  - See the output [here](https://github.com/stumpylog/Tasks.md/actions/runs/4394845265/jobs/7696159813#step:3:1)
- Use `docker/login-action` to handle authenticating to Docker Hub.
  - I couldn't fully test that portion, for obvious reason, but it should work identically
- Uses `docker/build-push-action` and associated
  - adds support for amd64, arm64 and armv7
  - handles the image tags and labels from the metadata
  - Could support caching if desired
- Some initial logic that could allow pull requests to build, but not push the image