### PR TITLE
Centring the tag button text within the modal

### DIFF
--- a/frontend/public/stylesheets/index.css
+++ b/frontend/public/stylesheets/index.css
@@ -321,6 +321,10 @@ button.small {
   margin-bottom: 12px;
 }
 
+.modal__tags .tag {
+  padding: 6px;
+}
+
 .disabled {
   pointer-events: none;
 }


### PR DESCRIPTION
# What
Making the tag "button" text centred, like the "Add Tag" button:

Before:
<img width="264" alt="Before screenshot" src="https://user-images.githubusercontent.com/12701930/224579020-20479a52-fad7-4888-a4ad-ec43a43f1245.png">

After:
<img width="264" alt="After screenshot" src="https://user-images.githubusercontent.com/12701930/224579018-f64e859c-2725-415c-be8e-b1aa2b75feb2.png">

Scoped to just the modal tags, so the tags on the page/in the lanes aren't impacted.