### PR TITLE
Change default user to root

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -9,8 +9,8 @@ const multer = require('@koa/multer');
 const send = require('koa-send')
 const mount = require('koa-mount');
 const serve = require('koa-static');
-const PUID = Number(process.env.PUID || '1000');
-const PGID = Number(process.env.PGID || '1000');
+const PUID = Number(process.env.PUID || '0');
+const PGID = Number(process.env.PGID || '0');
 const BASE_PATH = process.env.BASE_PATH ? `${process.env.BASE_PATH}/` : '/';
 const TASKS_DIR = process.env.NODE_ENV === 'prod' ? '/tasks' : 'tasks';
 const CONFIG_DIR = process.env.NODE_ENV === 'prod' ? '/config' : 'config';


### PR DESCRIPTION
When no UID and GID are given, sets files ownership to root when creating and editing files. This change was made to make it work similarly to [linuxserver containers](https://github.com/linuxserver/docker-documentation/blob/2bd34597a39e3e14a1cc31d75627b85b210c320b/general/understanding-puid-and-pgid.md)