### PR TITLE
Improve design for mobile devices

### DIFF
--- a/frontend/public/stylesheets/index.css
+++ b/frontend/public/stylesheets/index.css
@@ -57,6 +57,7 @@ strong {
   display: flex;
   gap: 40px;
   overflow-x: auto;
+  scroll-snap-type: x mandatory;
 }
 
 .lanes--has-title {
@@ -126,7 +127,8 @@ button.small {
   background: var(--app-header-background-color);
   border-bottom: 1px solid var(--app-header-border-color);
   box-sizing: border-box;
-  max-height: 57px;
+  max-width: 100%;
+  flex-wrap: wrap;
 }
 
 .search-input {
@@ -154,6 +156,7 @@ button.small {
 .lane {
   display: flex;
   flex-direction: column;
+  scroll-snap-align: center;
 }
 
 .dragged-over {
@@ -309,8 +312,8 @@ button.small {
   display: flex;
   flex-direction: column;
   position: relative;
-  width: 100%;
-  height: 100%;
+  width: 90%;
+  height: 90%;
   max-width: 960px;
   max-height: 819px;
   background: var(--modal-background-color);


### PR DESCRIPTION
Hello,

first of all thanks for the great work on this repository, I really like it and enjoy using it!

I would like to suggest some small design changes for mobile devices. This pull request will change the following:

- Add scroll snap for lanes: this will help for vertical scrolling on mobile devices as each lane will automatically snap into the center of the screen when the user scrolls vertically
- Wrap the header: the menu is currently cut off and you need to scroll on the menu to get e.g. to the "New lane" button. This is improved by wrapping the buttons that do not fit in the header in a second line
- Reduce size of modal: the modal was going until the edge of the screen, now it is reduced to have a little gap around it