### PR TITLE
Move stacks style to expanded card instead of globally

### DIFF
--- a/frontend/public/stylesheets/index-2.5.0.css
+++ b/frontend/public/stylesheets/index-2.5.0.css
@@ -48,7 +48,6 @@ strong {
 }
 
 ul,
-/* TODO explicit class styling because vite builds a different CSS file, once build config is changed this line can be removed */
 .tags {
   list-style-type: none;
   margin: 0;

--- a/frontend/src/components/expanded-card.jsx
+++ b/frontend/src/components/expanded-card.jsx
@@ -7,9 +7,9 @@ import {
 } from "solid-js";
 import { api } from "../api";
 import { StacksEditor } from "@stackoverflow/stacks-editor";
-import "@stackoverflow/stacks-editor/dist/styles.css";
 import "@stackoverflow/stacks";
-import "@stackoverflow/stacks/dist/css/stacks.css";
+import stacksEditorStyle from "@stackoverflow/stacks-editor/dist/styles.css?inline";
+import stacksStyle from "@stackoverflow/stacks/dist/css/stacks.css?inline";
 import { Menu } from "./menu";
 import { handleKeyDown, clickOutside } from "../utils";
 import { makePersisted } from "@solid-primitives/storage";
@@ -460,6 +460,12 @@ function ExpandedCard(props) {
 							</For>
 						</div>
 						<div class="dialog__content">
+							<style>
+								{stacksStyle}
+							</style>
+							<style>
+								{stacksEditorStyle}
+							</style>
 							<div
 								id="editor-container"
 								autofocus


### PR DESCRIPTION
StacksEditor style was causing unpredictable behavior on global style, moved it to a local tag inside expanded-card solved the issue