### PR TITLE
Make sure tasks folder exist when created using ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ COPY --from=build-stage --chown=$PUID:$PGID /app/dist/stylesheets/. /stylesheets
 COPY --from=build-stage --chown=$PUID:$PGID /api/ /api/
 RUN rm -r /static/stylesheets
 
+VOLUME /tasks
+VOLUME /config
 WORKDIR /api
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ COPY --from=build-stage --chown=$PUID:$PGID /app/dist/stylesheets/. /stylesheets
 COPY --from=build-stage --chown=$PUID:$PGID /api/ /api/
 RUN rm -r /static/stylesheets
 
-VOLUME /tasks
-VOLUME /config
 WORKDIR /api
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM node:18.20.4-alpine3.20 AS build-stage
 RUN apk add git
 RUN set -eux \
     && mkdir -p /app \
-    && mkdir -p /api \
-    && mkdir -p /tasks
+    && mkdir -p /api
 
 COPY frontend/ /app
 
@@ -52,7 +51,8 @@ WORKDIR /api
 EXPOSE 8080
 
 
-ENTRYPOINT mkdir -p ${CONFIG_DIR}/stylesheets/ && \
+ENTRYPOINT mkdir -p ${TASKS_DIR} && \
+           mkdir -p ${CONFIG_DIR}/stylesheets/ && \
            mkdir -p ${CONFIG_DIR}/images/ && \
            mkdir -p ${CONFIG_DIR}/sort/ && \
            cp -r ${CONFIG_DIR}/stylesheets/. /stylesheets/ && \


### PR DESCRIPTION
When setting the `TASKS_DIR` using the ENV variables, it's possible this directory doesn't exist. This change makes it so the directory will get created, similar to how the `CONFIG_DIR` gets created.

I've removed the VOLUME tags as they shouldn't be used together with bind mounts. I'm not sure if this is the best option right now, it might break existing configurations, I can revert that commit if you want.

Some additional context: I'm working on making this into a ready to use Home Assistant addon, I can mount their data directory to the `/tasks` directory, but it also contains some other files which mess up the structure. Using the ENV variable I am able to store the data in a subfolder, but it doesn't exist yet initially :) 