### PR TITLE
Ignore lanes and cards whose names start with dot

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,7 @@ async function getLanesNames() {
     .then(dirs => dirs
       .filter(dir => dir.isDirectory())
       .map(dir => dir.name)
+      .filter(dirName => !dirName.startsWith('.'))
     );
 }
 
@@ -33,12 +34,13 @@ async function getMdFiles() {
     lanes.map((lane) =>
       fs.promises
         .readdir(`${process.env.TASKS_DIR}/${lane}`)
-        .then((files) => files.map((file) => ({ lane, name: file })))
+        .then((files) => files
+        .map((file) => ({ lane, name: file })))
     )
   );
   const files = lanesFiles
     .flat()
-    .filter(file => file.name.endsWith('.md'));
+    .filter(file => file.name.endsWith('.md') && !file.name.startsWith("."));
   return files;
 }
 
@@ -131,7 +133,7 @@ async function getLaneByCardName(cardName) {
 
 async function getLanes(ctx) {
   const lanes = await fs.promises.readdir(process.env.TASKS_DIR);
-  ctx.body = lanes;
+  ctx.body = lanes.filter(dirName => !dirName.startsWith('.'));
 }
 
 router.get("/lanes", getLanes);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -403,6 +403,9 @@ function App() {
 		if (newName === "") {
 			return `The ${item} must have a name`;
 		}
+		if (newName.startsWith('.')) {
+			return 'Cards and lanes with names starting with dot are hidden';
+		}
 		if (namesList.filter((name) => name === (newName || "").trim()).length) {
 			return `There's already a ${item} with that name`;
 		}


### PR DESCRIPTION
As a standard behavior of filesystems, the application will now ignore files whose names start with .

Implemets #163 