### PR TITLE
docs: Fix migration-guide link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A self-hosted, Markdown file based task management board.
 - Can be installed as PWA.
 
 ## Upgrade from 2.X.X to 3.X.X
-If you're running a docker container with version 2 of Tasks.md and want to upgrade it to version 3, please follow up [those instructions](/public/migration-guide.md) as it requires some tweeks for it to work properly.
+If you're running a docker container with version 2 of Tasks.md and want to upgrade it to version 3, please follow up [those instructions](/migration-guide.md) as it requires some tweeks for it to work properly.
 
 ## 🐋 Installation
 ### Docker


### PR DESCRIPTION
A recent addition to the README to include a migration guide appears to reference a non-existant folder. This change updates the link to correctly refer to the migration guide.