### PR TITLE
fix: URL encoding for card names with # character to prevent navigation crashes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -142,7 +142,7 @@ router.post("/resource/:path*", createResource);
 async function updateResource(ctx) {
   const oldPath = decodeURI(ctx.request.url.substring("/resources".length));
   const newPath = decodeURI(ctx.request.body.newPath || oldPath).replaceAll(
-    /<>:"\/\\\|\?\*/g,
+    /<>:"\/\\\|\?\*#/g,
     " "
   );
   if (newPath !== oldPath) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -26,7 +26,7 @@ const multerInstance = multer();
 const app = new Koa();
 
 async function getTags(ctx) {
-  const subPath = decodeURI(ctx.request.url.substring("/tags".length));
+  const subPath = decodeURIComponent(ctx.request.url.substring("/tags".length));
   const tags = await fs.promises
     .readFile(`${CONFIG_DIR}/tags.json`)
     .then((res) => JSON.parse(res.toString()))
@@ -39,7 +39,7 @@ async function getTags(ctx) {
 router.get("/tags/:path*", getTags);
 
 async function updateTagBackgroundColor(ctx) {
-  const subPath = decodeURI(ctx.request.url.substring("/tags".length));
+  const subPath = decodeURIComponent(ctx.request.url.substring("/tags".length));
   const tags = await fs.promises
     .readFile(`${CONFIG_DIR}/tags.json`)
     .then((res) => JSON.parse(res.toString() || "{}"))
@@ -64,12 +64,12 @@ router.get("/title", getTitle);
 async function getResource(ctx) {
   const path = ctx.request.url.substring("/resources".length);
   const resources = await fs.promises.readdir(
-    `${TASKS_DIR}/${decodeURI(path)}`,
+    `${TASKS_DIR}/${decodeURIComponent(path)}`,
     { withFileTypes: true }
   ).catch(err => {
     console.log(err.code)
     if (err.code === 'ENOENT') {
-      fs.promises.mkdir(`${TASKS_DIR}/${decodeURI(path)}`)
+      fs.promises.mkdir(`${TASKS_DIR}/${decodeURIComponent(path)}`)
       return [];
     }
   })
@@ -80,7 +80,7 @@ async function getResource(ctx) {
   const lanesWithFiles = await Promise.all(
     lanes.map(async (lane) => {
       const filesPromises = await fs.promises
-        .readdir(`${TASKS_DIR}/${decodeURI(`${path}`)}/${lane}`)
+        .readdir(`${TASKS_DIR}/${decodeURIComponent(`${path}`)}/${lane}`)
         .then((files) =>
           files
             .filter(
@@ -89,12 +89,12 @@ async function getResource(ctx) {
             )
             .map(async (fileName) => {
               const getFileContent = fs.promises.readFile(
-                `${TASKS_DIR}/${decodeURI(
+                `${TASKS_DIR}/${decodeURIComponent(
                   `${path}`
                 )}/${lane}/${fileName}`
               );
               const getFileStats = fs.promises.stat(
-                `${TASKS_DIR}/${decodeURI(
+                `${TASKS_DIR}/${decodeURIComponent(
                   `${path}`
                 )}/${lane}/${fileName}`
               );
@@ -123,7 +123,7 @@ async function getResource(ctx) {
 router.get("/resource/:path*", getResource);
 
 async function createResource(ctx) {
-  const subPath = decodeURI(ctx.request.url.substring("/resources".length));
+  const subPath = decodeURIComponent(ctx.request.url.substring("/resources".length));
   const isFile = ctx.request.body?.isFile;
   const content = ctx.request.body?.content || "";
   if (isFile) {
@@ -140,8 +140,8 @@ async function createResource(ctx) {
 router.post("/resource/:path*", createResource);
 
 async function updateResource(ctx) {
-  const oldPath = decodeURI(ctx.request.url.substring("/resources".length));
-  const newPath = decodeURI(ctx.request.body.newPath || oldPath).replaceAll(
+  const oldPath = decodeURIComponent(ctx.request.url.substring("/resources".length));
+  const newPath = decodeURIComponent(ctx.request.body.newPath || oldPath).replaceAll(
     /<>:"\/\\\|\?\*#/g,
     " "
   );
@@ -170,7 +170,7 @@ async function updateResource(ctx) {
 router.patch("/resource/:path*", updateResource);
 
 async function deleteResource(ctx) {
-  const subPath = decodeURI(ctx.request.url.substring("/resources".length));
+  const subPath = decodeURIComponent(ctx.request.url.substring("/resources".length));
   await fs.promises.rm(`${TASKS_DIR}/${subPath}`, {
     force: true,
     recursive: true,
@@ -205,7 +205,7 @@ async function uploadImage(ctx) {
 router.post("/image", multerInstance.single("file"), uploadImage);
 
 async function updateSort(ctx) {
-  const subPath = decodeURI(ctx.request.url.substring("/sort".length));
+  const subPath = decodeURIComponent(ctx.request.url.substring("/sort".length));
   const newSort = { [subPath]: ctx.request.body || {} };
   const currentSort = await fs.promises
     .readFile(`${CONFIG_DIR}/sort.json`)
@@ -225,7 +225,7 @@ async function updateSort(ctx) {
 router.put("/sort/:path*", updateSort);
 
 async function getSort(ctx) {
-  const subPath = decodeURI(ctx.request.url.substring("/sort".length));
+  const subPath = decodeURIComponent(ctx.request.url.substring("/sort".length));
   const sort = await fs.promises
     .readFile(`${CONFIG_DIR}/sort.json`)
     .then((res) => JSON.parse(res.toString()))

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -236,7 +236,7 @@ function App() {
     const newCard = newCards[newCardIndex];
     newCard.content = newContent;
     await fetch(
-      `${api}/resource${board()}/${newCard.lane}/${newCard.name}.md`,
+      `${api}/resource${board()}/${newCard.lane}/${encodeURIComponent(newCard.name)}.md`,
       {
         method: "PATCH",
         mode: "cors",
@@ -281,7 +281,7 @@ function App() {
     const localTagOptions = cardTagOptions.filter((tag) => !tagsOptions().some(remoteTag => remoteTag.name === tag.name))
     const allTagOptions = [...tagsOptions(), ...localTagOptions];
     setTagsOptions(allTagOptions);
-    navigate(`${basePath()}${board()}/${newCard.name}.md`);
+    navigate(`${basePath()}${board()}/${encodeURIComponent(newCard.name)}.md`);
   }
 
   function getTagsByCardContent(text) {
@@ -314,7 +314,7 @@ function App() {
     const newCards = structuredClone(cards());
     const newCard = { lane };
     const newCardName = v7();
-    await fetch(`${api}/resource${board()}/${lane}/${newCardName}.md`, {
+    await fetch(`${api}/resource${board()}/${lane}/${encodeURIComponent(newCardName)}.md`, {
       method: "POST",
       mode: "cors",
       headers: { "Content-Type": "application/json" },
@@ -330,7 +330,7 @@ function App() {
 
   function deleteCard(card) {
     const newCards = structuredClone(cards());
-    fetch(`${api}/resource${board()}/${card.lane}/${card.name}.md`, {
+    fetch(`${api}/resource${board()}/${card.lane}/${encodeURIComponent(card.name)}.md`, {
       method: "DELETE",
       mode: "cors",
     });
@@ -434,13 +434,13 @@ function App() {
 
   function handleOnSelectedCardNameChange(newName) {
     renameCard(selectedCard().name, newName);
-    navigate(`${basePath()}${board()}/${newName}.md`);
+    navigate(`${basePath()}${board()}/${encodeURIComponent(newName)}.md`);
   }
 
   function handleDeleteCardsByLane(lane) {
     const cardsToDelete = cards().filter((card) => card.lane === lane);
     for (const card of cardsToDelete) {
-      fetch(`${api}/resource${board()}/${lane}/${card.name}.md`, {
+      fetch(`${api}/resource${board()}/${lane}/${encodeURIComponent(card.name)}.md`, {
         method: "DELETE",
         mode: "cors",
       });
@@ -454,7 +454,7 @@ function App() {
     const newCardIndex = newCards.findIndex((card) => card.name === oldName);
     const newCard = newCards[newCardIndex];
     const newCardNameWithoutSpaces = newName.trim();
-    fetch(`${api}/resource${board()}/${newCard.lane}/${newCard.name}.md`, {
+    fetch(`${api}/resource${board()}/${newCard.lane}/${encodeURIComponent(newCard.name)}.md`, {
       method: "PATCH",
       mode: "cors",
       headers: { "Content-Type": "application/json" },
@@ -488,7 +488,7 @@ function App() {
           card.name === selectedCard().name && card.lane === selectedCard().lane
       )
     );
-    navigate(`${basePath()}${board()}/${cards()[newCardIndex].name}.md`);
+    navigate(`${basePath()}${board()}/${encodeURIComponent(cards()[newCardIndex].name)}.md`);
   }
 
   function validateName(newName, namesList, item) {
@@ -504,8 +504,8 @@ function App() {
     if (namesList.filter((name) => name === (newName || "").trim()).length) {
       return `There's already a ${item} with that name`;
     }
-    if (/[<>:"/\\|?*]/g.test(newName)) {
-      return `The new name cannot have any of the following chracters: <>:"/\\|?*`;
+    if (/[<>:"/\\|?*#]/g.test(newName)) {
+      return `The new name cannot have any of the following chracters: <>:"/\\|?*#`;
     }
     if (newName.endsWith(".md")) {
       return "Name must not end with .md";
@@ -730,7 +730,7 @@ function App() {
                           if (board()) {
                             cardUrl += `${board()}`;
                           }
-                          cardUrl += `/${card.name}.md`;
+                          cardUrl += `/${encodeURIComponent(card.name)}.md`;
                           navigate(cardUrl);
                         }}
                         headerSlot={
@@ -767,7 +767,7 @@ function App() {
                               onDelete={() => deleteCard(card)}
                               onClick={() =>
                                 navigate(
-                                  `${basePath()}${board()}/${card.name}.md`
+                                  `${basePath()}${board()}/${encodeURIComponent(card.name)}.md`
                                 )
                               }
                             />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -504,8 +504,8 @@ function App() {
     if (namesList.filter((name) => name === (newName || "").trim()).length) {
       return `There's already a ${item} with that name`;
     }
-    if (/[<>:"/\\|?*#]/g.test(newName)) {
-      return `The new name cannot have any of the following chracters: <>:"/\\|?*#`;
+    if (/[<>:"/\\|?*]/g.test(newName)) {
+      return `The new name cannot have any of the following chracters: <>:"/\\|?*`;
     }
     if (newName.endsWith(".md")) {
       return "Name must not end with .md";


### PR DESCRIPTION
When creating a note with a title containing the # character (e.g., "Essential C# work"), the app would crash when clicking on the note. Additionally, such notes could not be deleted. I believe this was due to improper handling of the # character in URLs.