### PR TITLE
Adjust confirm delete text

### DIFF
--- a/frontend/src/components/menu.jsx
+++ b/frontend/src/components/menu.jsx
@@ -92,7 +92,7 @@ export function Menu(props) {
 							handleKeyDown(e, () => handleOptionConfirmation(e), close)
 						}
 					>
-						Are you sure?
+						Confirm
 					</button>
 					<button
 						type="button"


### PR DESCRIPTION
Just a text tweak to make the button a tad more clear.  The word `confirm` seems to make most sense on hover, not on hover, and on click (vs "are you sure?").

<img width="488" height="224" alt="Screenshot 2025-10-21 at 11 28 33 AM" src="https://github.com/user-attachments/assets/13a4241b-f686-44cf-9345-1e68b1d5d49f" />
