### PR TITLE
Implemented keyboard (arrow/vim) navigation

### DIFF
--- a/KEYBOARD_SHORTCUTS.md
+++ b/KEYBOARD_SHORTCUTS.md
@@ -1,0 +1,37 @@
+# Keyboard Shortcuts for Tasks.md
+
+## Navigation
+
+| Key        | Action                                                        |
+| ---------- | ------------------------------------------------------------- |
+| `↑` or `k` | Move focus to the card above (vim-style)                      |
+| `↓` or `j` | Move focus to the card below (vim-style)                      |
+| `←` or `h` | Move focus to the first card in the previous lane (vim-style) |
+| `→` or `l` | Move focus to the first card in the next lane (vim-style)     |
+| `Alt+↑`    | Move the focused card up within its current lane              |
+| `Alt+↓`    | Move the focused card down within its current lane            |
+| `Alt+←`    | Move the focused card to the previous lane                    |
+| `Alt+→`    | Move the focused card to the next lane                        |
+
+## Card Actions
+
+| Key            | Action                                                                |
+| -------------- | --------------------------------------------------------------------- |
+| `Enter` or `e` | Open/edit the currently focused card                                  |
+| `n`            | Create a new card in the current lane (or first lane if none focused) |
+| `r`            | Rename the currently focused card                                     |
+| `d`            | Delete the currently focused card (with confirmation)                 |
+
+## General
+
+| Key   | Action                                    |
+| ----- | ----------------------------------------- |
+| `Esc` | Clear focus and return to main board view |
+| `?`   | Show keyboard shortcuts help dialog       |
+
+## Expanded Card (Dialog) View
+
+When a card is expanded:
+
+- `Esc` - Close the card and return focus to it on the main board
+- All standard editor shortcuts apply within the content editor

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,11 +6,8 @@ import {
   createMemo,
   createEffect,
   createResource,
-  onCleanup,
   batch,
 } from "solid-js";
-import { Portal } from "solid-js/web";
-import { IconClear } from "@stackoverflow/stacks-icons/icons";
 import ExpandedCard from "./components/expanded-card";
 import { debounce } from "@solid-primitives/scheduled";
 import { api } from "./api";
@@ -26,6 +23,7 @@ import { useLocation, useNavigate } from "@solidjs/router";
 import { v7 } from "uuid";
 import { addTagToContent, removeTagFromContent, setDueDateInContent, getTagsFromContent } from "./card-content-utils";
 import "./stylesheets/index.css";
+import { KeyboardNavigationDialog } from "./components/keyboard-navigation-dialog";
 
 function App() {
   const [lanes, setLanes] = createSignal([]);
@@ -904,6 +902,20 @@ function App() {
     }
   });
 
+  createEffect(() => {
+    let focusedElement;
+    if (focusedCardId()) {
+      focusedElement = document.getElementById(`card-${focusedCardId()}`)?.focus();
+    }
+    if (focusedLaneIndex()) {
+      const laneName = lanes()[focusedLaneIndex()];
+      focusedElement = document.getElementById(`lane-${laneName}`)?.focus();
+    }
+    if (focusedElement) {
+      focusedElement.scrollIntoView()
+    }
+  })
+
   function handleMainBoardKeyDown(e) {
     // Don't interfere with input fields
     if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') {
@@ -1403,82 +1415,7 @@ function App() {
         </Show>
       </Show>
       <Show when={showHelpDialog()}>
-        <Portal>
-          <div
-            class="dialog-backdrop"
-            onClick={() => setShowHelpDialog(false)}
-          >
-            <dialog
-              open
-              class="help-dialog"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div class="dialog__body help-dialog__body">
-                <div class="help-dialog__header">
-                  <h2 class="help-dialog__title">Keyboard Shortcuts</h2>
-                  <button
-                    type="button"
-                    class="dialog__toolbar-btn help-dialog__close-btn"
-                    onClick={() => setShowHelpDialog(false)}
-                    title="Close"
-                  >
-                    <span innerHTML={IconClear} />
-                  </button>
-                </div>
-
-                <div class="help-dialog__sections">
-                  <div class="help-dialog__section">
-                    <h3 class="help-dialog__section-title">Navigation</h3>
-                    <table class="help-dialog__table">
-                      <tbody>
-                        <tr><td class="help-dialog__key-cell">↑ or k</td><td class="help-dialog__desc-cell">Move focus to card above</td></tr>
-                        <tr><td class="help-dialog__key-cell">↓ or j</td><td class="help-dialog__desc-cell">Move focus to card below</td></tr>
-                        <tr><td class="help-dialog__key-cell">← or h</td><td class="help-dialog__desc-cell">Move focus to previous lane</td></tr>
-                        <tr><td class="help-dialog__key-cell">→ or l</td><td class="help-dialog__desc-cell">Move focus to next lane</td></tr>
-                        <tr><td class="help-dialog__key-cell">Alt+↑</td><td class="help-dialog__desc-cell">Move card up within lane</td></tr>
-                        <tr><td class="help-dialog__key-cell">Alt+↓</td><td class="help-dialog__desc-cell">Move card down within lane</td></tr>
-                        <tr><td class="help-dialog__key-cell">Alt+←</td><td class="help-dialog__desc-cell">Move card to previous lane</td></tr>
-                        <tr><td class="help-dialog__key-cell">Alt+→</td><td class="help-dialog__desc-cell">Move card to next lane</td></tr>
-                      </tbody>
-                    </table>
-                  </div>
-
-                  <div class="help-dialog__section">
-                    <h3 class="help-dialog__section-title">Card Actions</h3>
-                    <table class="help-dialog__table">
-                      <tbody>
-                        <tr><td class="help-dialog__key-cell">Enter or e</td><td class="help-dialog__desc-cell">Open/edit focused card</td></tr>
-                        <tr><td class="help-dialog__key-cell">n</td><td class="help-dialog__desc-cell">Create new card in current lane</td></tr>
-                        <tr><td class="help-dialog__key-cell">r</td><td class="help-dialog__desc-cell">Rename focused card</td></tr>
-                        <tr><td class="help-dialog__key-cell">d</td><td class="help-dialog__desc-cell">Delete focused card (with confirmation)</td></tr>
-                      </tbody>
-                    </table>
-                  </div>
-
-                  <div class="help-dialog__section">
-                    <h3 class="help-dialog__section-title">General</h3>
-                    <table class="help-dialog__table">
-                      <tbody>
-                        <tr><td class="help-dialog__key-cell">Esc</td><td class="help-dialog__desc-cell">Clear focus / Close dialog</td></tr>
-                        <tr><td class="help-dialog__key-cell">?</td><td class="help-dialog__desc-cell">Show this help dialog</td></tr>
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
-
-                <div class="help-dialog__footer">
-                  <button
-                    type="button"
-                    class="help-dialog__ok-btn"
-                    onClick={() => setShowHelpDialog(false)}
-                  >
-                    Close
-                  </button>
-                </div>
-              </div>
-            </dialog>
-          </div>
-        </Portal>
+        <KeyboardNavigationDialog onClose={() => setShowHelpDialog(false)} />
       </Show>
     </div>
   );

--- a/frontend/src/components/card.jsx
+++ b/frontend/src/components/card.jsx
@@ -13,6 +13,8 @@ import { handleKeyDown } from "../utils";
  * @param {boolean} props.selectionMode
  * @param {boolean} props.isSelected
  * @param {Function} props.onSelectionChange
+ * @param {boolean} props.isFocused
+ * @param {Function} props.onFocus
  */
 export function Card(props) {
 
@@ -39,15 +41,21 @@ export function Card(props) {
     }
     const [year, month, day] = props.dueDate.split('-')
     const dueDateLocalTime = new Date(year, month - 1, day);
-    return `Due ${dueDateLocalTime.toLocaleDateString()}` 
+    return `Due ${dueDateLocalTime.toLocaleDateString()}`
   })
 
   return (
     <div
       role="button"
       id={`card-${props.name}`}
-      class={`card ${props.disableDrag ? "card__drag-disabled" : ""} ${props.isSelected ? "card--selected" : ""}`}
-      onKeyDown={(e) => handleKeyDown(e, props.onClick)}
+      class={`card ${props.disableDrag ? "card__drag-disabled" : ""} ${props.isSelected ? "card--selected" : ""} ${props.isFocused ? "card--focused" : ""}`}
+      onKeyDown={(e) => {
+        // Only handle Enter key, let arrow keys bubble up to board-level handler
+        if (e.key === "Enter") {
+          handleKeyDown(e, props.onClick);
+        }
+      }}
+      onFocus={() => props.onFocus?.()}
       onClick={e => {
         const isDescendant = e.currentTarget === e.target || e.currentTarget.contains(e.target);
         if (!isDescendant) {

--- a/frontend/src/components/card.jsx
+++ b/frontend/src/components/card.jsx
@@ -13,7 +13,6 @@ import { handleKeyDown } from "../utils";
  * @param {boolean} props.selectionMode
  * @param {boolean} props.isSelected
  * @param {Function} props.onSelectionChange
- * @param {boolean} props.isFocused
  * @param {Function} props.onFocus
  */
 export function Card(props) {
@@ -48,7 +47,7 @@ export function Card(props) {
     <div
       role="button"
       id={`card-${props.name}`}
-      class={`card ${props.disableDrag ? "card__drag-disabled" : ""} ${props.isSelected ? "card--selected" : ""} ${props.isFocused ? "card--focused" : ""}`}
+      class={`card ${props.disableDrag ? "card__drag-disabled" : ""} ${props.isSelected ? "card--selected" : ""}`}
       onKeyDown={(e) => {
         // Only handle Enter key, let arrow keys bubble up to board-level handler
         if (e.key === "Enter") {

--- a/frontend/src/components/expanded-card.jsx
+++ b/frontend/src/components/expanded-card.jsx
@@ -320,6 +320,13 @@ function ExpandedCard(props) {
     }
   }
 
+  function handleDialogKeyDown(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      handleDialogCancel();
+    }
+  }
+
   function handleChangeDueDate(e) {
     const newContent = setDueDateInContent(props.content, e.target.value);
     editor().content = newContent;
@@ -343,9 +350,7 @@ function ExpandedCard(props) {
             dialogRef = el;
           }}
           class={`${isMaximized() === "true" ? "dialog--maximized" : ""}`}
-          onKeyDown={(e) =>
-            handleKeyDown(e, (event) => event.stopPropagation())
-          }
+          onKeyDown={handleDialogKeyDown}
           onCancel={handleDialogCancel}
         >
           <div class="dialog__body">

--- a/frontend/src/components/keyboard-navigation-dialog.jsx
+++ b/frontend/src/components/keyboard-navigation-dialog.jsx
@@ -1,0 +1,136 @@
+import { Portal } from "solid-js/web";
+import { IconClear } from "@stackoverflow/stacks-icons/icons";
+
+export function KeyboardNavigationDialog(props) {
+  return (
+    <Portal>
+      <div class="dialog-backdrop" onClick={() => setShowHelpDialog(false)}>
+        <dialog open class="help-dialog" onClick={(e) => e.stopPropagation()}>
+          <div class="dialog__body help-dialog__body">
+            <div class="help-dialog__header">
+              <h2 class="help-dialog__title">Keyboard Shortcuts</h2>
+              <button
+                type="button"
+                class="dialog__toolbar-btn help-dialog__close-btn"
+                onClick={() => props.onClose()}
+                title="Close"
+              >
+                <span innerHTML={IconClear} />
+              </button>
+            </div>
+
+            <div class="help-dialog__sections">
+              <div class="help-dialog__section">
+                <h3 class="help-dialog__section-title">Navigation</h3>
+                <table class="help-dialog__table">
+                  <tbody>
+                    <tr>
+                      <td class="help-dialog__key-cell">↑ or k</td>
+                      <td class="help-dialog__desc-cell">
+                        Move focus to card above
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">↓ or j</td>
+                      <td class="help-dialog__desc-cell">
+                        Move focus to card below
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">← or h</td>
+                      <td class="help-dialog__desc-cell">
+                        Move focus to previous lane
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">→ or l</td>
+                      <td class="help-dialog__desc-cell">
+                        Move focus to next lane
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">Alt+↑</td>
+                      <td class="help-dialog__desc-cell">
+                        Move card up within lane
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">Alt+↓</td>
+                      <td class="help-dialog__desc-cell">
+                        Move card down within lane
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">Alt+←</td>
+                      <td class="help-dialog__desc-cell">
+                        Move card to previous lane
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">Alt+→</td>
+                      <td class="help-dialog__desc-cell">
+                        Move card to next lane
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <div class="help-dialog__section">
+                <h3 class="help-dialog__section-title">Card Actions</h3>
+                <table class="help-dialog__table">
+                  <tbody>
+                    <tr>
+                      <td class="help-dialog__key-cell">Enter or e</td>
+                      <td class="help-dialog__desc-cell">
+                        Open/edit focused card
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">n</td>
+                      <td class="help-dialog__desc-cell">
+                        Create new card in current lane
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">r</td>
+                      <td class="help-dialog__desc-cell">
+                        Rename focused card
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">d</td>
+                      <td class="help-dialog__desc-cell">
+                        Delete focused card (with confirmation)
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
+              <div class="help-dialog__section">
+                <h3 class="help-dialog__section-title">General</h3>
+                <table class="help-dialog__table">
+                  <tbody>
+                    <tr>
+                      <td class="help-dialog__key-cell">Esc</td>
+                      <td class="help-dialog__desc-cell">
+                        Clear focus / Close dialog
+                      </td>
+                    </tr>
+                    <tr>
+                      <td class="help-dialog__key-cell">?</td>
+                      <td class="help-dialog__desc-cell">
+                        Show this help dialog
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </dialog>
+      </div>
+    </Portal>
+  );
+}

--- a/frontend/src/stylesheets/index.css
+++ b/frontend/src/stylesheets/index.css
@@ -848,6 +848,17 @@ a > * {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 
+.card--focused {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(var(--color-accent-rgb, 59, 130, 246), 0.1);
+}
+
+.card--focused:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 /* Header button active state */
 .button--active {
   background: var(--color-accent) !important;

--- a/frontend/src/stylesheets/index.css
+++ b/frontend/src/stylesheets/index.css
@@ -498,6 +498,76 @@ dialog:not(.dialog--maximized) {
   flex-direction: column;
 }
 
+/* Help dialog (keyboard shortcuts) */
+dialog.help-dialog {
+  width: auto;
+  height: auto;
+  max-width: 400px;
+  max-height: 80vh;
+}
+
+.help-dialog__body {
+  padding: 20px;
+  gap: 16px;
+  overflow: auto;
+  line-height: 1.2;
+}
+
+.help-dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.help-dialog__title {
+  margin: 0;
+  font-size: 20px;
+  color: var(--color-foreground);
+}
+
+.help-dialog__sections {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.help-dialog__section-title {
+  margin-top: 0;
+  margin-bottom: 8px;
+  font-size: 14px;
+  color: var(--color-foreground);
+}
+
+.help-dialog__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.help-dialog__key-cell {
+  padding: 3px 12px 3px 0;
+  font-family: monospace;
+  white-space: nowrap;
+  color: var(--color-foreground);
+}
+
+.help-dialog__desc-cell {
+  padding: 3px 0;
+  color: var(--color-foreground);
+}
+
+.help-dialog__footer {
+  text-align: center;
+  margin-top: 12px;
+}
+
+.help-dialog__ok-btn {
+  padding: 6px 20px;
+}
+
 .input-and-error-msg {
   position: relative;
   display: flex;
@@ -846,17 +916,6 @@ a > * {
   outline: 1px solid var(--color-accent);
   outline-offset: 2px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-
-.card--focused {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-  box-shadow: 0 0 0 4px rgba(var(--color-accent-rgb, 59, 130, 246), 0.1);
-}
-
-.card--focused:focus {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
 }
 
 /* Header button active state */


### PR DESCRIPTION
# Add Comprehensive Keyboard Navigation

## Summary
Adds full keyboard navigation support for managing cards and lanes without requiring mouse interaction.

## Important
Please note that web (js/ts) programming is not my forte, so I relied heavily on Claude 4.5 for much of this implementation, but with very heavy and thorough guidance and dozens of iterative local builds and testing. That said, if you are not interested in this PR, I can understand. It was fully intended for my own personal use on my local machine via PWA install (using Firefox).

## Changes

### Navigation
- **Arrow keys / vim keys (h/j/k/l)**: Navigate between cards and lanes
- **Auto-focus**: First card in first lane is focused on app load
- **Empty lane handling**: Navigation skips empty lanes when moving left/right

### Card Movement
- **Alt+Arrow keys**: Move cards between lanes (left/right) or reorder within lanes (up/down)
- **Focus preservation**: Card remains focused after being moved

### Focus Management
- **Auto-restore**: Focus returns to card after creating, renaming, or closing expanded view
- **Escape key**: Clears focus and returns to main board
- **Expanded card**: Escape key closes dialog

### Help Dialog
- **? key**: Opens styled keyboard shortcuts dialog

### Modified Files
- `frontend/src/App.jsx`: Main keyboard navigation logic, card movement functions, help dialog
- `frontend/src/components/card.jsx`: Modified key handler to allow arrow keys to bubble up
- `frontend/src/components/expanded-card.jsx`: Added Escape key handler
- `KEYBOARD_SHORTCUTS.md`: Updated documentation with new shortcuts

## Testing
- [x] Navigation works in all directions
- [x] Alt+Arrow keys move cards correctly
- [x] Empty lanes are skipped during navigation
- [x] Focus is preserved after card operations
- [x] Help dialog displays correctly
- [x] Escape key closes dialogs and clears focus

## Breaking Changes
None found. Bulk operations still operate as expected in my testing.

## Example of usage:

### Video clip of "in action"

https://github.com/user-attachments/assets/c37f7e2a-9de5-4e38-9a15-dab55ac44d2b

### "?" triggered shortcut menu

<img width="619" height="669" alt="image_20251109181346" src="https://github.com/user-attachments/assets/aa67da29-ad62-4e43-86b3-106bb19bf07f" />

